### PR TITLE
Missing name change tm-obs-switcher -> tm-switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ information about obtaining these can be found in the [REC Foundation Knowledge 
 1. Clone or download this repository
 
 ```
-git clone git@github.com:brenapp/tm-obs-switcher.git
+git clone git@github.com:brenapp/tm-switcher.git
 cd tm-obs-switcher
 ```
 

--- a/switcher/main.ts
+++ b/switcher/main.ts
@@ -22,7 +22,7 @@ import "./behaviors/logging";
 import "./behaviors/heartbeat";
 
 async function main() {
-  console.log(`tm-obs-switcher v${require("../../package.json").version}`);
+  console.log(`tm-switcher v${require("../../package.json").version}`);
   console.log("Created by Brendan McGuire (brendan@bren.app)\n");
 
   // Logging


### PR DESCRIPTION
Corrected a couple of places where the name change from tm-obs-switcher to tm-switcher where missed.